### PR TITLE
Move deprecation comment to annotation

### DIFF
--- a/units/src/main/scala/units/SI.scala
+++ b/units/src/main/scala/units/SI.scala
@@ -390,8 +390,7 @@ object SI {
 		type µA = microampere
 		type nA = nanoampere
 
-		/** Will be removed in 0.3.0 */
-		@deprecated
+		@deprecated("Will be removed in 0.3.0", "0.2.1")
 		type Hr = henry
 		type H  = henry
 		type mH = millihenry


### PR DESCRIPTION
Annotation `scala.deprecated` allows to set `message` and `version` in which the definition was deprecated.
Setting these fields will give much better compiler warnings.
