### PR TITLE
Constants were corrected for metric prefixes in the numeric units builder

### DIFF
--- a/units/src/main/scala/package.scala
+++ b/units/src/main/scala/package.scala
@@ -127,22 +127,22 @@ package object units {
 			WithU[N,U](n.times(underlyingValue,n.fromInt(10)))
 		@inline
 		def hecto[U<:MUnit](implicit n:Numeric[N]) =
-			WithU[N,U](n.times(underlyingValue,n.fromInt(10)))
+			WithU[N,U](n.times(underlyingValue,n.fromInt(100)))
 		@inline
 		def deka[U<:MUnit] (implicit n:Numeric[N]) =
 			WithU[N,U](n.times(underlyingValue,n.fromInt(10)))
 		@inline
 		def hekto[U<:MUnit](implicit n:Numeric[N]) =
-			WithU[N,U](n.times(underlyingValue,n.fromInt(10)))
+			WithU[N,U](n.times(underlyingValue,n.fromInt(100)))
 		@inline
 		def kilo[U<:MUnit] (implicit n:Numeric[N]) =
-			WithU[N,U](n.times(underlyingValue,n.fromInt(10)))
+			WithU[N,U](n.times(underlyingValue,n.fromInt(1000)))
 		@inline
 		def mega[U<:MUnit] (implicit n:Numeric[N]) =
-			WithU[N,U](n.times(underlyingValue,n.fromInt(10)))
+			WithU[N,U](n.times(underlyingValue,n.fromInt(1000000)))
 		@inline
 		def giga[U<:MUnit] (implicit n:Numeric[N]) =
-			WithU[N,U](n.times(underlyingValue,n.fromInt(10)))
+			WithU[N,U](n.times(underlyingValue,n.fromInt(1000000000)))
 
 	}
 


### PR DESCRIPTION
In `io.github.karols.units.WithUBuilder` it seems that all of `deca[U]`, `deck[U]`, `hecto[U]`, `hekto[U]`, `kilo[U]`, `mega[U]` and `giga[U]` are implemented as for `deca[U]`, i.e. multiplied with 10, not 100 for `hecto`, 1000 for `kilo` and etc. The correction is proposed.